### PR TITLE
update codewords nz-file with mode=0 decoding and other changes

### DIFF
--- a/src/dec_iter.c
+++ b/src/dec_iter.c
@@ -36,11 +36,11 @@ void cnt_out(int print_banner, const params_t * const p){
   if(print_banner){
     printf("# P_FAIL N_TOT FAIL S_TOT ");
     if(p->uW>=0)
-      printf(": C_TRIVIAL S_TRIVIAL  ");
+      printf(": C_TRIVIAL F_TRIVIAL  ");
     if(p->uW>0)
-      printf(" C_LOW S_LOW  C_CLUS S_CLUS ");
+      printf("%s C_CLUS F_CLUS %s", p->uX & 1? " C_LOW F_LOW ":"", p->uX & 2? " C_PART S_PART F_PART ":"");
     if(p->mode==0)
-      printf(": FAIL_RIS N_RIS S_RIS\n");
+      printf(": N_RIS S_RIS FAIL_RIS\n");
     else
       printf(": FAIL_BP N_BP   C_BP C_BP_AVG C_BP_TOT   S_BP S_OSD\n");    
   }
@@ -48,12 +48,16 @@ void cnt_out(int print_banner, const params_t * const p){
 	 (double ) (cnt[TOTAL]-cnt[SUCC_TOT])/cnt[TOTAL],
 	 cnt[TOTAL], cnt[TOTAL]-cnt[SUCC_TOT], cnt[SUCC_TOT]);
   if(p->uW>=0)
-    printf(": %lld %lld \t", cnt[CONV_TRIVIAL], cnt[SUCC_TRIVIAL]);
-  if(p->uW>0) // use cluster-based pre-decoding
-    printf(" %lld %lld \t %lld %lld ",
-	   cnt[CONV_LOWW], cnt[SUCC_LOWW], cnt[CONV_CLUS], cnt[SUCC_CLUS]);
+    printf(": %lld %lld \t", cnt[CONV_TRIVIAL], cnt[CONV_TRIVIAL] - cnt[SUCC_TRIVIAL]);
+  if(p->uW>0){ // use cluster-based pre-decoding
+    if (p->uX & 1)
+      printf(" %lld %lld \t",  cnt[CONV_LOWW], cnt[CONV_LOWW] - cnt[SUCC_LOWW]);
+    printf(" %lld %lld ",  cnt[CONV_CLUS], cnt[CONV_CLUS] - cnt[SUCC_CLUS]);
+    if (p->uX & 2)
+      printf(" %lld %lld %lld \t",  cnt[PART_CLUS], cnt[PART_SUCC], cnt[PART_CONV] - cnt[PART_SUCC]);
+  }
   if(p->mode==0)
-    printf(": %lld %lld %lld \n",cnt[CONV_RIS]-cnt[SUCC_RIS], cnt[CONV_RIS],cnt[SUCC_RIS]);
+    printf(": %lld %lld %lld \n",cnt[CONV_RIS],cnt[SUCC_RIS], cnt[CONV_RIS]-cnt[SUCC_RIS]);
   else{ 
     printf(": %lld %lld \t %lld %lld %lld \t %lld  %lld\n",
 	   cnt[NUMB_BP]-cnt[SUCC_BP]-cnt[SUCC_OSD], cnt[NUMB_BP], cnt[CONV_BP], cnt[CONV_BP_AVG], cnt[CONV_BP_TOT],
@@ -570,8 +574,6 @@ int do_serialV_BP(qllr_t * outLLR, const mzd_t * const srow,
 
   return succ_BP;
 }
-
-
 
 /** @brief recursive part of OSD */
 int do_osd_recurs(const int minrow, const rci_t jstart, const int lev, qllr_t vE[], mzd_t *mE,

--- a/src/dec_pre.c
+++ b/src/dec_pre.c
@@ -142,13 +142,14 @@ static inline int ufl_verify(const ufl_t * const u){
   vnode_t *nod, *tmp;
   int cnt=0;
   HASH_ITER(hh, u->nodes, nod, tmp) {
-    if(cnt > u->nvar){
+    if(cnt > u->nvar + u ->nchk){
       num_err++; break;
     }
     cnt++;
   }
   if((cnt != u->num_s) || (num_err))
-    ERROR("counted %d expected num_s=%d num_err=%d",cnt, u->num_v, num_err);
+    ERROR("counted %d expected num_s=%d num_v=%d num_c=%d num_err=%d",cnt,
+          u->num_s, u->num_v, u->num_c, num_err);
   return 0;
 }
 
@@ -388,7 +389,8 @@ void dec_ufl_clear(ufl_t * const u){
     u->clus[i].first_c = u->clus[i].last_c = NULL;
     u->clus[i].num_poi_c=0;
   }
-  u->num_v = u->num_c = u->num_clus = u->num_prop = u->wei_c = 0;
+  u->num_v = u->num_c = u->num_s = 0;
+  u->num_clus = u->num_prop = u->wei_c = 0;
   u->error->wei = u->syndr->wei = 0;
 }
 

--- a/src/dec_pre.c
+++ b/src/dec_pre.c
@@ -1142,7 +1142,8 @@ int ufl_decompose(const int wei, const int * const vec, ufl_t * u, params_t * p)
               HASH_ADD_INT(hash,idx,nod);
               wei_b ++; /* new observable node */
             }
-            printf("added/updated b=%d @ cluster %d, val=%d wei_b=%d\n",b,cl,nod->val,wei_b);
+            if(p->debug&32)
+              printf("added/updated b=%d @ cluster %d, val=%d wei_b=%d\n",b,cl,nod->val,wei_b);
           }
         }
         /** clear the hash */

--- a/src/mtx_qc.c
+++ b/src/mtx_qc.c
@@ -310,10 +310,13 @@ int main(int argc, char **argv){
 
   const size_t siz=1000;
   char comment[siz+1];
-  snprintf(comment,siz,"QC block matrix [%d,%d] ell=%d",p->rows,p->cols, p->ell);
+  int rank = rank_csr(p->mat);
+  snprintf(comment,siz,"QC block matrix [%d,%d] ell=%d rank=%d",p->rows,p->cols, p->ell, rank);
   comment[siz]='\0';/** sanity check */
   csr_mm_write(p->out,"" /** no extension */, p->mat, comment);
   if(p->mat) csr_free(p->mat);
+  if(p->debug&1)
+    printf("# wrote %s to %s\n",comment,p->out);
   return 0;
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -70,9 +70,13 @@ FILE * nzlist_r_open(const char fnam[], long long int *lineno){
   FILE *f=fopen(fnam,"r");
   if(!f)
     return(NULL);
+#if 0
   if((EOF == fscanf(f,"%%%% NZLIST %n",&cnt)) || (cnt<9))
     ERROR("invalid signature line, expected '%%%% NZLIST'");
-  *lineno=2;  
+  *lineno=2;
+#else /* treat signature line as comment */
+  *lineno=1;
+#endif   
   char c=fgetc(f); /** are there comments to skip? */  //  putchar(c);
   while(c=='%'){ /** `comment line` starting with '%' */
     do{

--- a/src/utils.c
+++ b/src/utils.c
@@ -66,11 +66,11 @@ int nzlist_w_append(FILE *f, const one_vec_t * const vec){
 
 /** @brief prepare to read from an `NZLIST` file; return NULL if no file found */
 FILE * nzlist_r_open(const char fnam[], long long int *lineno){
-  int cnt;
   FILE *f=fopen(fnam,"r");
   if(!f)
     return(NULL);
 #if 0
+  int cnt;
   if((EOF == fscanf(f,"%%%% NZLIST %n",&cnt)) || (cnt<9))
     ERROR("invalid signature line, expected '%%%% NZLIST'");
   *lineno=2;

--- a/src/utils.h
+++ b/src/utils.h
@@ -185,6 +185,33 @@ static inline int by_syndrome(void *a, void *b){
   /** @brief print entire `one_vec_t` structure by pointer */
   void print_one_vec(const one_vec_t * const pvec);
 
+/** @brierf init `one_vec_t` structure from an array of integers */
+static inline one_vec_t * one_vec_init(one_vec_t *vec, const int wei, const int arr[]){
+  if ((vec!=NULL)&&(vec->weight < wei)){
+    free(vec);
+    vec=NULL;
+  }
+  if(vec==NULL){
+    vec = calloc(sizeof(one_vec_t) + wei*sizeof(int), sizeof(char));
+    if(!vec)
+      ERROR("memory allocation");
+  }
+  
+  vec->weight = wei;
+  vec->cnt = 1;
+  for(int i=0; i<wei; i++)
+    vec->arr[i] = arr[i];
+#ifndef NDEBUG
+  for(int i=1; i<wei; i++){ /** verify entry just read */
+    if((vec->arr[i-1] < 0) || (vec->arr[i-1] >= vec->arr[i])){
+      printf("invalid entry of weight w=%d\n",wei);
+      ERROR("expected strictly increasing positive entries");
+    }   
+  }
+#endif
+  return vec;
+}
+
   /** @brief compare two `one_vec_t` structures by energy */
   static inline int by_energy(void *a, void *b){
   const one_vec_t *pa = (one_vec_t *) a;

--- a/src/vecdec.c
+++ b/src/vecdec.c
@@ -615,7 +615,7 @@ void do_hash_decomp(params_t *const p){
     int reduc = ufl_decompose(cw->weight, cw->arr, ufl, p);
     if(reduc){
       cnt_reduc++;
-      if(p->debug&1){
+      if(p->debug&2){
         printf("reducible! ");
         print_one_vec(cw);
         ufl_print(ufl,2);
@@ -654,7 +654,7 @@ void do_hash_decomp(params_t *const p){
                 p->maxW_rec = cw->weight;
               cw=NULL; /** the `cw` is used in the hash, can't be reused */
             }
-            else if(p->debug&1){
+            else if(p->debug&2){
                 printf("cl=%d already there ",cl);
                 print_one_vec(cw);                
             }

--- a/src/vecdec.c
+++ b/src/vecdec.c
@@ -2015,9 +2015,9 @@ int var_init(int argc, char **argv, params_t *p){
     p->mLe = mzd_init(p->ncws,  p->nvec); /** each column `L*e` vector */
     if((p->ferr) || (p->outC))
       p->mEt = mzd_init(p->nvar, p->nvec);
-    if((p->uX&2)&&(p->outC))
-      ERROR("mode=%d submode=%d uX=%d (bit 1) and outC=%s are currently"
-            " incompatible\n", p->mode, p->submode, p->uX, p->outC);
+    //    if((p->uX&2)&&(p->outC))
+    //      ERROR("mode=%d submode=%d uX=%d (bit 1) and outC=%s are currently"
+    //            " incompatible\n", p->mode, p->submode, p->uX, p->outC);
     if(p->fer0)
       p->mE0 = mzd_init(p->mA->cols, p->nvec);
     if(p->debug &1){
@@ -2406,12 +2406,13 @@ int main(int argc, char **argv){
 	  }
 	  if(ic<ierr_tot){ 
 	    if(p->outC){
-#if 1	      
-	      if(status[ic]>0){
-		printf("j=%d ic=%d status=%d vec: ",j,ic,status[ic]);
-		tmpvec = vec_from_mzd_row(tmpvec,mE0,ic);
-		vec_print(tmpvec);
-	      }
+#ifndef NDEBUG
+              if(p->debug&32)
+                if(status[ic]>0){
+                  printf("j=%d ic=%d status=%d vec: ",j,ic,status[ic]);
+                  tmpvec = vec_from_mzd_row(tmpvec,mE0,ic);
+                  vec_print(tmpvec);
+                }
 #endif 
 	      //	      assert(status[ic] <= 0);
 	      if((p->maxC == 0)||((p->maxC > 0) && (p->num_cws < p->maxC))){

--- a/src/vecdec.c
+++ b/src/vecdec.c
@@ -157,7 +157,7 @@ double est_prob_one_wei(const int num, const int nvar, const double * const valP
     }
     weight += binomialC(num,s) * mul;
   }
-#if 1
+#if 0
   printf("# num=%d avg=%g sig=%g wei=%Lg\n",num,avg,sig,0.5*weight);
 #endif 
   return 0.5*pref*weight;

--- a/src/vecdec.c
+++ b/src/vecdec.c
@@ -32,7 +32,7 @@ params_t prm={ .nchk=-1, .nvar=-1, .ncws=-1, .steps=50,
   .lerr=-1, .maxosd=100, .swait=0, .maxC=0,
   .dW=0, .minW_rec=INT_MAX, .maxW_rec=0, .maxW=0, .dE=-1, .dEdbl=-1, .minE=INT_MAX,
   .bpalpha=1, .bpbeta=1, .bpgamma=0.5, .bpretry=1, 
-  .uW=1, .uX=0, .uR=0, //.uEdbl=-1, .uE=-1,
+  .uW=2, .uX=0, .uR=1, //.uEdbl=-1, .uE=-1,
   .numU=0, .numE=0, .maxU=0,
   .hashU_error=NULL, .hashU_syndr=NULL, .permHe=NULL,
   .nvec=1024, .ntot=1, .nfail=0, .seed=0, .epsilon=1e-8,
@@ -65,7 +65,7 @@ params_t prm={ .nchk=-1, .nvar=-1, .ncws=-1, .steps=50,
 params_t prm_default={  .steps=50, 
   .lerr=-1, .maxosd=100, .bpgamma=0.5, .bpretry=1, .swait=0, .maxC=0,
   .dW=0, .minW_rec=INT_MAX, .maxW_rec=-1, .maxW=0, .dE=-1, .dEdbl=-1, .minE=INT_MAX,
-  .uW=1, .uX=0, .uR=0, //.uEdbl=-1, .uE=-1,
+  .uW=2, .uX=0, .uR=1, //.uEdbl=-1, .uE=-1,
   .maxU=0, .bpalpha=1, .bpbeta=1,
   .nvec=1024, .ntot=1, .nfail=0, .seed=0, .epsilon=1e-8, .useP=0, .mulP=0, .dmin=0,
   .useQ=0, .refQ=0, .debug=1, .fout="tmp", .ferr=NULL,
@@ -1024,7 +1024,8 @@ void init_Ht(params_t *p){
 	if(p->uR==0)
 	  printf("# uW=%d, adding errors of weight up to %d to syndrome hash\n",p->uW, p->uW);
 	else 
-	  printf("# uW=%d, adding error clusters of w <= %d and radius <= uR=%d to syndrome hash\n",p->uW, p->uW, p->uR);
+	  printf("# uW=%d, adding error clusters of w <= %d and radius <= uR=%d \n"
+                 "#   between v-v neighbors to syndrome hash\n",p->uW, p->uW, p->uR);
 	if(p->maxU)
 	  printf("# maximum number of error syndromes in hash maxU=%lld\n",p->maxU);
 	printf("# uX=%d,%s",p->uX, p->uX > 0 ? "":" disable experimental options for cluster decoding\n");

--- a/src/vecdec.h
+++ b/src/vecdec.h
@@ -73,7 +73,8 @@ typedef struct POINT_T {
 
 typedef struct VNODE_T {
   UT_hash_handle hh;
-  int v; /** key: variable node */
+  int idx; /** key: `v`ariable node or `nvar`+`c`heck node */
+  int val; /** node value (e.g., `0` or `1`) */
   int clus; /** cluster reference */
 } vnode_t;
 
@@ -99,7 +100,6 @@ typedef struct UFL_T {
   const int nvar;
   const int nchk;
   vnode_t * nodes; /** hash storage for occupied nodes */
-  /** TODO: compare performance for taking an int array of nodes instead */
   int num_v; /** total number of used `v_nodes` (all clusters) */
   int num_c; /** total number of used `c_nodes` */
   int num_clus; /** number of defined clusters */

--- a/src/vecdec.h
+++ b/src/vecdec.h
@@ -90,7 +90,7 @@ typedef struct CLUSTER_T {
    *   TODO: implement negative label = deleted cluster.
    */
   int wei_c; /** syndrome weight */
-  //  int wei_b; /** o`b`servable weight */
+  int wei_b; /** o`b`servable weight */
   //  int wei_v;
   int num_poi_v;
   point_t *first_v; /** linked list for associated v-nodes */
@@ -372,11 +372,11 @@ typedef struct UFL_T {
 /** @brief construct an empty ufl structure */
 ufl_t *ufl_init(const params_t * const p);
 /** @brief print out the `ufl` and its clusters */
- void ufl_print(const ufl_t *const u);
+void ufl_print(const ufl_t *const u, const int bitmap);
 /** given a sparse vector (`wei` sorted variable nodes in `vec`), construct its
  * cluster decomposition in u; return 0 if reducible */
 int ufl_decompose(const int wei, const int * const vec, ufl_t * u, params_t * p);
-    
+int do_clus_error(const int cl, ufl_t * const u, const int clear);    
   /**
    * @brief The help message.
    *

--- a/src/vecdec.h
+++ b/src/vecdec.h
@@ -99,16 +99,19 @@ typedef struct CLUSTER_T {
 typedef struct UFL_T {
   const int nvar;
   const int nchk;
+  int wei_c; /* syndrome weight */
+  //  int wei_v;
   vnode_t * nodes; /** hash storage for occupied nodes */
   int num_v; /** total number of used `v_nodes` (all clusters) */
   int num_c; /** total number of used `c_nodes` */
+  int num_s; /** total number of used `spare` nodes in hash */
   int num_clus; /** number of defined clusters */
   int num_prop; /** number of proper (non-reference and non-deleted) clusters */
   vec_t *error; /** [`nvar`] current error vector */
   vec_t *syndr; /** [`nchk`] remaining syndrome bits */
   point_t *v_nodes; /** [`nvar`] pre-allocated nodes for `v` linked lists in clusters */
   point_t *c_nodes; /** [`nchk`] same for `c` linked lists */
-  vnode_t * spare;  /** [`nvar`] same for `hash` look-up table in `nodes`*/
+  vnode_t * spare;  /** [`nvar`+`nchk`] same for `hash` look-up table in `nodes`*/
   cluster_t clus[0];/** [`nchk`] list of clusters and associated `v` and `c` lists. */
 } ufl_t;
 

--- a/src/vecdec.h
+++ b/src/vecdec.h
@@ -383,7 +383,7 @@ typedef struct UFL_T {
   "\t finL=[string]\t: file with logical dual check matrix Lx (mm or alist)\n" \
   "\t finK=[string]\t: file with logical check matrix Lz (mm or alist)\n" \
   "\t finP=[string]\t: input file for probabilities (mm or a column of doubles)\n" \
-  "\t finQ=[string]\t: input file for alt probabilities (for use with mode 2.8)\n" \
+  "\t finQ=[string]\t: input file for alt probabilities (for use with mode 2.16)\n" \
   "\t finA=[string]\t: additional matrix to correct syndromes (mm or alist)\n" \
   "\t finC=[string]\t: input file name for codewords in `nzlist` format\n" \
   "\t\t (space is OK in front of file names to enable shell completion)\n" \
@@ -405,8 +405,8 @@ typedef struct UFL_T {
   "\t mulP=[double]\t: scale probability values from DEM file\n"	\
   "\t\t for a quantum code specify 'fdem' OR 'finH' and ( 'finL' OR 'finG' );\n" \
   "\t\t for classical just 'finH' or 'finHT' (and optionally the dual matrix 'finL')\n" \
-  "\t useQ=[double]\t: alt fixed probability value for use with mode 2.8\n" \
-  "\t refQ=[double]\t: reference error probability for use with mode 2.8\n" \
+  "\t useQ=[double]\t: alt fixed probability value for use with mode 2.16\n" \
+  "\t refQ=[double]\t: reference error probability for use with mode 2.16\n" \
   "\t ferr=[string]\t: input file with error vectors (01 format)\n"	\
   "\t fer0=[string]\t: add'l error to correct det events 's+A*e0' (01 format)\n" \
   "\t\t where matrix 'A' is given via 'finA', 's' via 'fdet', and 'e0'\n" \
@@ -561,10 +561,11 @@ typedef struct UFL_T {
 #define HELP2 /** help for `mode=2` */  \
   " mode=2 : Generate most likely fault vectors, estimate Prob(Fail).\n" \
   "\tSubmode bitmap values:\n"						\
-  "\t\t\t .1 (bit 0) calculate original fail probability estimate\n"	\
-  "\t\t\t .2 (bit 1) calculate exact greedy probability estimate\n"	\
-  "\t\t\t .4 (bit 2) reserved\n"					\
-  "\t\t\t .8 (bit 3) use reference `refQ/finQ/useQ` to calculate fail\n"\
+  "\t\t\t .1  (bit 0) calculate original fail probability estimate\n"	\
+  "\t\t\t .2  (bit 1) fail prob estimate using average LLRs and cw count\n" \
+  "\t\t\t .4  (bit 2) calculate exact greedy probability estimate\n"	\
+  "\t\t\t .8  (bit 3) approx greedy prob estimate with prefactor\n"     \
+  "\t\t\t .16 (bit 4) use reference `refQ/finQ/useQ` to calculate fail\n" \
   "\t\t\t\t probability estimates (as opposed to direct summations)\n"	\
   "\t Use up to 'steps' random information set (RIS) steps\n"		\
   "\t unless no new codewords (fault vectors) have been found for 'swait' steps.\n" \
@@ -581,7 +582,7 @@ typedef struct UFL_T {
   "\t Use 'useP' to override error probability values in DEM file.   \n" \
   "\t Use 'mulP' to scale error probability values from DEM file.   \n" \
   "\t Similarly, use 'finQ' or 'useQ' arguments to specify alternative\n" \
-  "\t probability vectors with mode 2.8\n"                              \
+  "\t probability vectors with mode 2.16\n"                              \
   "\n"
 
 #define HELP3 /** help for `mode=3` */  \

--- a/src/vecdec.h
+++ b/src/vecdec.h
@@ -144,7 +144,7 @@ typedef struct UFL_T {
     char *finK; /** `input file` name for Lz=K (not used much) */
     char *finG; /** `input file` name for Hz=G (must use separate input) */
     char *finP; /** `input file` name for P (if input separately or a classical code) */
-    char *finQ; /** `input file` name for Q (extra set of probabilities for mode `2.4`) */
+    char *finQ; /** `input file` name for Q (extra set of probabilities for mode `2.8`) */
     char *finC; /** `input file` name for `C` (list of non-trivial CWs for decoding) */
     char *outC; /** `output file` name for `C` (list of non-trivial CWs for decoding) */
     char *fout; /** `output file name`  header for files creaded with `mode=3` */
@@ -177,12 +177,13 @@ typedef struct UFL_T {
     long long int seed;  /** rng `seed`, set<=0 for automatic */
     double useP; /** global error probability `overriding` values in the `DEM` file (default: 0, no override)
 		  negative value means weight-only mode (no probabilities specified) */
-    double useQ; /** global error probability for use with mode `2.4` file (default: 0, not specified) */
+    double useQ; /** global error probability for use with mode `2.8` file (default: 0, not specified) */
     double mulP; /** scale error probability values in the `DEM` file (default: 0, no scaling) */
     double *vP; /** probability vector (total of `n`) */
-    double *vQ; /** alternative probability vector (total of `n`) for use with mode `2.4` */
+    double *vQ; /** alternative probability vector (total of `n`) for use with mode `2.8` */
     double refQ; /** reference fail rate corresponding to `Q` probabilities */
     qllr_t *vLLR; /** vector of LLRs (total of `n`) */
+    qllr_t *vLLRQ; /** vector of LLRs for the reference distribution (total of `n`) */
     int minW_rec; /** minimum weight of a codeword or error vector found */
     int maxW_rec; /** max weight of a codeword or error vector found */
     int dW; /** if non-negative, weight over `minW` to keep the CW or error vector in a hash (default: `0`, `minW` only) */
@@ -353,7 +354,7 @@ typedef struct UFL_T {
   "\t finL=[string]\t: file with logical dual check matrix Lx (mm or alist)\n" \
   "\t finK=[string]\t: file with logical check matrix Lz (mm or alist)\n" \
   "\t finP=[string]\t: input file for probabilities (mm or a column of doubles)\n" \
-  "\t finQ=[string]\t: input file for alt probabilities (for use with mode 2.4)\n" \
+  "\t finQ=[string]\t: input file for alt probabilities (for use with mode 2.8)\n" \
   "\t finA=[string]\t: additional matrix to correct syndromes (mm or alist)\n" \
   "\t finC=[string]\t: input file name for codewords in `nzlist` format\n" \
   "\t\t (space is OK in front of file names to enable shell completion)\n" \
@@ -373,8 +374,8 @@ typedef struct UFL_T {
   "\t mulP=[double]\t: scale probability values from DEM file\n"	\
   "\t\t for a quantum code specify 'fdem' OR 'finH' and ( 'finL' OR 'finG' );\n" \
   "\t\t for classical just 'finH' or 'finHT' (and optionally the dual matrix 'finL')\n" \
-  "\t useQ=[double]\t: alt fixed probability value for use with mode 2.4\n" \
-  "\t refQ=[double]\t: reference error probability for use with mode 2.4\n" \
+  "\t useQ=[double]\t: alt fixed probability value for use with mode 2.8\n" \
+  "\t refQ=[double]\t: reference error probability for use with mode 2.8\n" \
   "\t ferr=[string]\t: input file with error vectors (01 format)\n"	\
   "\t fer0=[string]\t: add'l error to correct det events 's+A*e0' (01 format)\n" \
   "\t\t where matrix 'A' is given via 'finA', 's' via 'fdet', and 'e0'\n" \
@@ -532,8 +533,9 @@ typedef struct UFL_T {
   "\tSubmode bitmap values:\n"						\
   "\t\t\t .1 (bit 0) calculate original fail probability estimate\n"	\
   "\t\t\t .2 (bit 1) calculate exact greedy probability estimate\n"	\
-  "\t\t\t .4 (bit 2) use refence probability `refQ` to calculate fail\n"\
-  "\t\t\t\t probability estimate\n"                                     \
+  "\t\t\t .4 (bit 2) reserved\n"					\
+  "\t\t\t .8 (bit 3) use reference `refQ/finQ/useQ` to calculate fail\n"\
+  "\t\t\t\t probability estimates (as opposed to direct summations)\n"	\
   "\t Use up to 'steps' random information set (RIS) steps\n"		\
   "\t unless no new codewords (fault vectors) have been found for 'swait' steps.\n" \
   "\t Use 'steps=0' to just use the codewords from the file \n"		\
@@ -543,13 +545,13 @@ typedef struct UFL_T {
   "\t If 'outC' is set, write full list of CWs to this file.\n"		\
   "\t If 'finC' is set, read initial set of CWs from this file.\n"	\
   "\t Accuracy and performance are determined by parameters \n"		\
-  "\t 'steps' (number of BP rounds), 'lerr' (OSD level, defaul=-1, no OSD).\n" \
+  "\t 'steps' (number of RIS rounds), 'lerr' (OSD level, defaul=-1, no OSD).\n" \
   "\t Specify a single DEM file 'fdem', or 'finH', 'finL', and 'finP'\n" \
   "\t separately (either 'finL' or 'finG' is needed for a quantum code).\n" \
   "\t Use 'useP' to override error probability values in DEM file.   \n" \
   "\t Use 'mulP' to scale error probability values from DEM file.   \n" \
   "\t Similarly, use 'finQ' or 'useQ' arguments to specify alternative\n" \
-  "\t probability vectors with mode 2.4\n"                              \
+  "\t probability vectors with mode 2.8\n"                              \
   "\n"
 
 #define HELP3 /** help for `mode=3` */  \

--- a/src/vecdec.h
+++ b/src/vecdec.h
@@ -178,7 +178,7 @@ typedef struct UFL_T {
     int uW; /** max weight of an error vector in `U` hash (default: `2`) */
     int uX; /** bitmap: 1 (bit 0) try low-weight clusters; 
 	     *	        2 (bit 1) use partial pre-decoder cluster matches (default: `0`) */
-    int uR; /** max distance between v-v neighbors for errors in syndrome hash (default: `4`) */
+    int uR; /** max distance between v-v neighbors for errors in syndrome hash (default: `1`) */
     two_vec_t *hashU_error; /** `U` hash location by error vector */
     two_vec_t *hashU_syndr; /** `U` hash location by syndrome */
     int *permHe; /** permutation vector for syndrome bits when hashU is used */
@@ -408,7 +408,7 @@ int do_clus_error(const int cl, ufl_t * const u, const int clear);
   "\t uW=[integer]\t: max weight of an error cluster in hash (default: 2)\n" \
   "\t\t ('0': no hash but skip zero-weight syndrome vectors; '-1': do not skip)\n" \
   "\t uR=[integer]\t: max range of v-v neighbors for errors in syndrome hash\n" \
-  "\t\t (use '0' for no limit; default: 4)\n"				\
+  "\t\t (use '0' for no limit; recommended default: 1)\n"				\
   "\t uX=[integer]\t: bitmap for cluster-based predecoder options (default: 0)\n" \
   "\t\t 1 (bit 0) try low-weight error w/o cluster decomp (recommend with 'uR=0'); \n" \
   "\t\t 2 (bit 1) use partial cluster matches (experimental)\n"		\
@@ -509,7 +509,7 @@ int do_clus_error(const int cl, ufl_t * const u, const int clear);
   "\t With 'uW' non-negative, use hash storage to store likely syndrome\n" \
   "\t\t vectors to speed up the decoding.  Parameter 'maxU>0' sets the limit on the\n" \
   "\t\t number of syndrome vectors in the hash; no limit if 'maxU=0'.  \n"	\
-  "\t\t Parameter 'uR>0' sets the limit on the graph distance between non-zero positions\n" \
+  "\t\t Parameter 'uR>0' sets the limit on the v-v graph distance between non-zero positions\n" \
   "\t\t in an error vector stored in the hash; no limit if 'uR=0'\n"	\
   "\t\t Bitmap 'uX', when non-zero, enables experimental options for cluster-based\n" \
   "\t\t predecoder: try to match syndrome as a whole (bit 0), and using partially\n" \

--- a/src/vecdec.h
+++ b/src/vecdec.h
@@ -144,6 +144,7 @@ typedef struct UFL_T {
     char *finK; /** `input file` name for Lz=K (not used much) */
     char *finG; /** `input file` name for Hz=G (must use separate input) */
     char *finP; /** `input file` name for P (if input separately or a classical code) */
+    char *finQ; /** `input file` name for Q (extra set of probabilities for mode `2.4`) */
     char *finC; /** `input file` name for `C` (list of non-trivial CWs for decoding) */
     char *outC; /** `output file` name for `C` (list of non-trivial CWs for decoding) */
     char *fout; /** `output file name`  header for files creaded with `mode=3` */
@@ -176,8 +177,11 @@ typedef struct UFL_T {
     long long int seed;  /** rng `seed`, set<=0 for automatic */
     double useP; /** global error probability `overriding` values in the `DEM` file (default: 0, no override)
 		  negative value means weight-only mode (no probabilities specified) */
+    double useQ; /** global error probability for use with mode `2.4` file (default: 0, not specified) */
     double mulP; /** scale error probability values in the `DEM` file (default: 0, no scaling) */
     double *vP; /** probability vector (total of `n`) */
+    double *vQ; /** alternative probability vector (total of `n`) for use with mode `2.4` */
+    double refQ; /** reference fail rate corresponding to `Q` probabilities */
     qllr_t *vLLR; /** vector of LLRs (total of `n`) */
     int minW_rec; /** minimum weight of a codeword or error vector found */
     int maxW_rec; /** max weight of a codeword or error vector found */
@@ -349,6 +353,7 @@ typedef struct UFL_T {
   "\t finL=[string]\t: file with logical dual check matrix Lx (mm or alist)\n" \
   "\t finK=[string]\t: file with logical check matrix Lz (mm or alist)\n" \
   "\t finP=[string]\t: input file for probabilities (mm or a column of doubles)\n" \
+  "\t finQ=[string]\t: input file for alt probabilities (for use with mode 2.4)\n" \
   "\t finA=[string]\t: additional matrix to correct syndromes (mm or alist)\n" \
   "\t finC=[string]\t: input file name for codewords in `nzlist` format\n" \
   "\t\t (space is OK in front of file names to enable shell completion)\n" \
@@ -368,6 +373,8 @@ typedef struct UFL_T {
   "\t mulP=[double]\t: scale probability values from DEM file\n"	\
   "\t\t for a quantum code specify 'fdem' OR 'finH' and ( 'finL' OR 'finG' );\n" \
   "\t\t for classical just 'finH' or 'finHT' (and optionally the dual matrix 'finL')\n" \
+  "\t useQ=[double]\t: alt fixed probability value for use with mode 2.4\n" \
+  "\t refQ=[double]\t: reference error probability for use with mode 2.4\n" \
   "\t ferr=[string]\t: input file with error vectors (01 format)\n"	\
   "\t fer0=[string]\t: add'l error to correct det events 's+A*e0' (01 format)\n" \
   "\t\t where matrix 'A' is given via 'finA', 's' via 'fdet', and 'e0'\n" \
@@ -413,7 +420,7 @@ typedef struct UFL_T {
   "\t\t\t see the source code for more options\n"			\
   "\t See program documentation for input file syntax.\n"               \
   "\t Multiple 'debug' parameters are XOR combined except for 0.\n"	\
-  "\t Use debug=0 as the 1st argument to suppress all debug messages.\n"
+  "\n"
 
 #if 0  
 #define XXX \
@@ -525,6 +532,8 @@ typedef struct UFL_T {
   "\tSubmode bitmap values:\n"						\
   "\t\t\t .1 (bit 0) calculate original fail probability estimate\n"	\
   "\t\t\t .2 (bit 1) calculate exact greedy probability estimate\n"	\
+  "\t\t\t .4 (bit 2) use refence probability `refQ` to calculate fail\n"\
+  "\t\t\t\t probability estimate\n"                                     \
   "\t Use up to 'steps' random information set (RIS) steps\n"		\
   "\t unless no new codewords (fault vectors) have been found for 'swait' steps.\n" \
   "\t Use 'steps=0' to just use the codewords from the file \n"		\
@@ -539,6 +548,8 @@ typedef struct UFL_T {
   "\t separately (either 'finL' or 'finG' is needed for a quantum code).\n" \
   "\t Use 'useP' to override error probability values in DEM file.   \n" \
   "\t Use 'mulP' to scale error probability values from DEM file.   \n" \
+  "\t Similarly, use 'finQ' or 'useQ' arguments to specify alternative\n" \
+  "\t probability vectors with mode 2.4\n"                              \
   "\n"
 
 #define HELP3 /** help for `mode=3` */  \

--- a/todo.md
+++ b/todo.md
@@ -623,6 +623,9 @@ observable or soft-out row), and rows not-yet decoded.
       original error vector, decompose the difference to connected clusters, and
       pick irreducible non-trivial codewords; update in the hash and finally
       save updated list to a file.
+  - [x] with `mode=0`
+  - [ ] with `mode=1`
+  - [ ] make sure it respects `dW` parameter
 - [x] Make sure two probability vectors can be read in mode=2, along with the
       reference fail rate, to generate better prediction.
 - [x] ~~For experiments, randomly select certain fraction of codewords (e.g.,

--- a/todo.md
+++ b/todo.md
@@ -618,7 +618,7 @@ observable or soft-out row), and rows not-yet decoded.
 
 ## new items 2025/07/02
 
-- [ ] update / generate cluster list when running a decoder (when original error
+- [x] update / generate cluster list when running a decoder (when original error
       vectors are available).  Namely, for every decoding error, subtract the
       original error vector, decompose the difference to connected clusters, and
       pick irreducible non-trivial codewords; update in the hash and finally
@@ -631,7 +631,7 @@ observable or soft-out row), and rows not-yet decoded.
 - [x] ~~For experiments, randomly select certain fraction of codewords (e.g.,
       when reading from a file), study what would be sufficient.~~ (do it
       separately, using `shuf` on the `nz` file.)
-- [ ] experiment with exact and approximate probability values
-- [ ] add prefactor calculation for mode=2.1 (separate for odd / even weights?)
-- [ ] add mode=2.4 with more accurate and faster calculation
+- [x] experiment with exact and approximate probability values
+- [x] add prefactor calculation for mode=2.1 (separate for odd / even weights)
+- [x] add mode=2.4 with more accurate and faster calculation
 - [ ] what would be a sufficient statistics?  Experiment.

--- a/todo.md
+++ b/todo.md
@@ -623,8 +623,12 @@ observable or soft-out row), and rows not-yet decoded.
       original error vector, decompose the difference to connected clusters, and
       pick irreducible non-trivial codewords; update in the hash and finally
       save updated list to a file.
-- [ ] Make sure two probability vectors can be read in mode=2, along with the
+- [x] Make sure two probability vectors can be read in mode=2, along with the
       reference fail rate, to generate better prediction.
 - [x] ~~For experiments, randomly select certain fraction of codewords (e.g.,
       when reading from a file), study what would be sufficient.~~ (do it
       separately, using `shuf` on the `nz` file.)
+- [ ] experiment with exact and approximate probability values
+- [ ] add prefactor calculation for mode=2.1 (separate for odd / even weights?)
+- [ ] add mode=2.4 with more accurate and faster calculation
+- [ ] what would be a sufficient statistics?  Experiment.

--- a/todo.md
+++ b/todo.md
@@ -594,15 +594,16 @@ observable or soft-out row), and rows not-yet decoded.
        neighboring errors (Would it be sufficient to cover all
        weight-two clusters?  Why not?)
  - [ ] generalization for tree-like connected clusters of higher weight.
- - [ ] For `dist_m4ri`, add a mode for computing the confinement.
+ - [x] For `dist_m4ri`, add a mode for computing the confinement.
        Namely, store all errors/syndrome combinations by syndrome and
        the corresponding minimum weight error.
  - [ ] Come up with a notion of a distance suitable for SS two-step
        and SS one-step decoding.  At what minimum error/syndrome
        weight would a non-trivial error show up? (That would cause the
        decoding to fail).
- - [ ] Can we come up with a some sort of a *locality distance*?  That
-       is, error weight to guarantee decoding cluster locality.
+ - [ ] Can we come up with a some sort of a *locality distance*?  That is, error
+       weight to guarantee decoding cluster locality, when using window size
+       $T$.
  - [ ] Write a separate program for PRE+BP+OSD decoding, to save on
        matrix rewriting.  Try partial cluster matching (with the
        partially matched vectors correctly participating in the weight
@@ -614,3 +615,16 @@ observable or soft-out row), and rows not-yet decoded.
 ## new items 2014/11/19
 
 - [ ] make sure programs work with p=0.5 (and also with p>0.5)
+
+## new items 2025/07/02
+
+- [ ] update / generate cluster list when running a decoder (when original error
+      vectors are available).  Namely, for every decoding error, subtract the
+      original error vector, decompose the difference to connected clusters, and
+      pick irreducible non-trivial codewords; update in the hash and finally
+      save updated list to a file.
+- [ ] Make sure two probability vectors can be read in mode=2, along with the
+      reference fail rate, to generate better prediction.
+- [x] ~~For experiments, randomly select certain fraction of codewords (e.g.,
+      when reading from a file), study what would be sufficient.~~ (do it
+      separately, using `shuf` on the `nz` file.)

--- a/todo.md
+++ b/todo.md
@@ -635,3 +635,5 @@ observable or soft-out row), and rows not-yet decoded.
 - [x] add prefactor calculation for mode=2.1 (separate for odd / even weights)
 - [x] add mode=2.4 with more accurate and faster calculation
 - [ ] what would be a sufficient statistics?  Experiment.
+- [x] `bug`: with `uX=2` invalid codewords may be written (also, syndrome
+      mismatch with DEBUG enabled) (fixed)


### PR DESCRIPTION
- fixed a bug in partial-cluster matching for the pre-decoder
- changed default values for `uW=2` and `uR=1` (previously we had `uW=1` and `uR=0`)
- mode=2 decoder can now compare predicted and original error vectors to construct codewords (when actual error vectors are used)
- mode=2 several improvements (*undocumented* in README.md)
- partial documentation update